### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/gitops.yml
+++ b/.github/workflows/gitops.yml
@@ -17,7 +17,7 @@ jobs:
               run: |
                 CGO_ENABLED=0 go test ./...
             - name: publish to registry
-              uses: elgohr/Publish-Docker-Github-Action@master
+              uses: elgohr/Publish-Docker-Github-Action@v5
               with:
                 name: ${{ secrets.DOCKER_USERNAME }}/workshop-gitops
                 username: ${{ secrets.DOCKER_USERNAME }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore